### PR TITLE
Add missing concerns to export concerns documentation

### DIFF
--- a/3.1/exports/charts.md
+++ b/3.1/exports/charts.md
@@ -1,0 +1,86 @@
+# Charts
+
+[[toc]]
+
+By using the `WithCharts` concern, you can add one or multiple charts to your worksheet.
+
+## Instantiating a chart
+You first have to instantiate a new `PhpOffice\PhpSpreadsheet\Worksheet\Chart`, passing the name, title, legend and plot in the constructor.
+
+```php
+$label      = [new DataSeriesValues('String', 'Worksheet!$B$1', null, 1)];
+$categories = [new DataSeriesValues('String', 'Worksheet!$B$2:$B$5', null, 4)];
+$values     = [new DataSeriesValues('Number', 'Worksheet!$A$2:$A$5', null, 4)];
+
+$series = new DataSeries(DataSeries::TYPE_PIECHART, DataSeries::GROUPING_STANDARD,
+    range(0, \count($values) - 1), $label, $categories, $values);
+$plot   = new PlotArea(null, [$series]);
+
+$legend = new Legend();
+$chart  = new Chart('chart name', new Title('chart title'), $legend, $plot);
+```
+
+You can view all available properties for Charts on the [PhpSpreadsheet docs](https://phpoffice.github.io/PhpSpreadsheet/namespaces/phpoffice-phpspreadsheet-chart.html).
+
+## Adding a single chart
+When you've instantiated the chart, you can add the `WithCharts` concern to your export class and return the Chart instance in the `charts` method.
+
+```php
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\WithCharts;
+use PhpOffice\PhpSpreadsheet\Worksheet\Chart;
+
+class InvoicesExport implements WithCharts
+{
+    public function charts()
+    {
+        $label      = [new DataSeriesValues('String', 'Worksheet!$B$1', null, 1)];
+        $categories = [new DataSeriesValues('String', 'Worksheet!$B$2:$B$5', null, 4)];
+        $values     = [new DataSeriesValues('Number', 'Worksheet!$A$2:$A$5', null, 4)];
+
+        $series = new DataSeries(DataSeries::TYPE_PIECHART, DataSeries::GROUPING_STANDARD,
+            range(0, \count($values) - 1), $label, $categories, $values);
+        $plot   = new PlotArea(null, [$series]);
+
+        $legend = new Legend();
+        $chart  = new Chart('chart name', new Title('chart title'), $legend, $plot);
+
+        return $chart;
+    }
+}
+```
+
+## Adding multiple charts
+You can add multiple charts to the worksheet by returning an array in the `charts` method.
+
+```php
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\WithCharts;
+use PhpOffice\PhpSpreadsheet\Worksheet\Chart;
+
+class InvoicesExport implements WithCharts
+{
+    public function charts()
+    {
+        $label      = [new DataSeriesValues('String', 'Worksheet!$B$1', null, 1)];
+        $categories = [new DataSeriesValues('String', 'Worksheet!$B$2:$B$5', null, 4)];
+        $values     = [new DataSeriesValues('Number', 'Worksheet!$A$2:$A$5', null, 4)];
+
+        $series = new DataSeries(DataSeries::TYPE_PIECHART, DataSeries::GROUPING_STANDARD,
+            range(0, \count($values) - 1), $label, $categories, $values);
+        $plot   = new PlotArea(null, [$series]);
+
+        $legend = new Legend();
+        $chart  = new Chart('chart name', new Title('chart title'), $legend, $plot);
+        $chart2 = new Chart('chart 2 name', new Title('chart 2 title'), $legend, $plot);
+
+        return [$chart, $chart2];
+    }
+}
+```

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -12,6 +12,7 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\FromIterator`| Use an iterator to populate the export. | |
 |`Maatwebsite\Excel\Concerns\FromQuery`| Use an Eloquent query to populate the export. | [From Query](/3.1/exports/from-query.html) | 
 |`Maatwebsite\Excel\Concerns\FromView`| Use a (Blade) view to to populate the export. | [From View](/3.1/exports/from-view.html) |
+|`Maatwebsite\Excel\Concerns\HasReferencesToOtherSheets`| Allows precalculated values where one sheet has references to another sheet. | [References to other sheets](/3.1/exports/multiple-sheets.html#making-calculations-work-when-referencing-between-sheets) |
 |`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
 |`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
 |`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -14,7 +14,7 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\FromView`| Use a (Blade) view to to populate the export. | [From View](/3.1/exports/from-view.html) |
 |`Maatwebsite\Excel\Concerns\HasReferencesToOtherSheets`| Allows precalculated values where one sheet has references to another sheet. | [References to other sheets](/3.1/exports/multiple-sheets.html#making-calculations-work-when-referencing-between-sheets) |
 |`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
-|`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
+|`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | [Charts](/3.1/exports/charts.html) |
 |`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |
 |`Maatwebsite\Excel\Concerns\WithColumnWidths`| Set Column widths. | [Column widths](/3.1/exports/column-formatting.html#styling) |
 |`Maatwebsite\Excel\Concerns\WithCustomChunkSize`| Allows Exportables to define their chunk size. | |

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -8,19 +8,19 @@ pageClass: no-toc
 |---- |----|----|
 |`Maatwebsite\Excel\Concerns\FromArray`| Use an array to populate the export. | [Exporting collections](/3.1/exports/collection.html#using-arrays) |
 |`Maatwebsite\Excel\Concerns\FromCollection`| Use a Laravel Collection to populate the export. | [Exporting collections](/3.1/exports/collection.html) |
-|`Maatwebsite\Excel\Concerns\FromGenerator`| Use a generator to populate the export. | |
+|`Maatwebsite\Excel\Concerns\FromGenerator`| Use a generator to populate the export. | [From Generator](/3.1/exports/from-generator.html) |
 |`Maatwebsite\Excel\Concerns\FromIterator`| Use an iterator to populate the export. | |
 |`Maatwebsite\Excel\Concerns\FromQuery`| Use an Eloquent query to populate the export. | [From Query](/3.1/exports/from-query.html) | 
 |`Maatwebsite\Excel\Concerns\FromView`| Use a (Blade) view to to populate the export. | [From View](/3.1/exports/from-view.html) |
 |`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
 |`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
 |`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |
-|`Maatwebsite\Excel\Concerns\WithColumnWidths`| Set Column widths. | |
+|`Maatwebsite\Excel\Concerns\WithColumnWidths`| Set Column widths. | [Column widths](/3.1/exports/column-formatting.html#styling) |
 |`Maatwebsite\Excel\Concerns\WithCustomChunkSize`| Allows Exportables to define their chunk size. | |
 |`Maatwebsite\Excel\Concerns\WithCustomCsvSettings`| Allows to run custom Csv settings for this specific exportable. | [Custom CSV Settings](/3.1/exports/settings.html) |
 |`Maatwebsite\Excel\Concerns\WithCustomQuerySize`| Allows Exportables that implement the FromQuery concern to provide their own custom query size. | [Custom Query Size](/3.1/exports/queued.html#custom-query-size) |
 |`Maatwebsite\Excel\Concerns\WithCustomStartCell`| Allows to specify a custom start cell. Do note that this is only supported for FromCollection exports. | [Custom start cell](/3.1/exports/collection.html#custom-start-cell) |
-|`Maatwebsite\Excel\Concerns\WithCustomValueBinder`| Allows to specify a custom value binder. | |
+|`Maatwebsite\Excel\Concerns\WithCustomValueBinder`| Allows to specify a custom value binder. | [Custom Value Binder](/3.1/exports/column-formatting.html#value-binders) |
 |`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
 |`Maatwebsite\Excel\Concerns\WithEvents`| Register events to hook into the PhpSpreadsheet process. | [Events](/3.1/exports/extending.html#events) |
 |`Maatwebsite\Excel\Concerns\WithHeadings`| Prepend a heading row. | [Adding a heading row](/3.1/exports/mapping.html#adding-a-heading-row) |
@@ -29,7 +29,7 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\WithPreCalculateFormulas`| Forces PhpSpreadsheet to recalculate all formulae in a workbook when saving, so that the pre-calculated values are immediately available to MS Excel or other office spreadsheet viewer when opening the file. | |
 |`Maatwebsite\Excel\Concerns\WithProperties`| Allows setting properties on the document. (title, description, creator, lastModifiedBy, subject, keywords, category, manager, company) | |
 |`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null value. | [Strict null comparisons](/3.1/exports/collection.html#strict-null-comparisons) |
-|`Maatwebsite\Excel\Concerns\WithStyles`| Allows setting styles on worksheets. | |
+|`Maatwebsite\Excel\Concerns\WithStyles`| Allows setting styles on worksheets. | [Styles](/3.1/exports/column-formatting.html#styling) |
 |`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
 
 ### Traits

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -8,15 +8,19 @@ pageClass: no-toc
 |---- |----|----|
 |`Maatwebsite\Excel\Concerns\FromArray`| Use an array to populate the export. | [Exporting collections](/3.1/exports/collection.html#using-arrays) |
 |`Maatwebsite\Excel\Concerns\FromCollection`| Use a Laravel Collection to populate the export. | [Exporting collections](/3.1/exports/collection.html) |
+|`Maatwebsite\Excel\Concerns\FromGenerator`| Use a generator to populate the export. | |
 |`Maatwebsite\Excel\Concerns\FromIterator`| Use an iterator to populate the export. | |
 |`Maatwebsite\Excel\Concerns\FromQuery`| Use an Eloquent query to populate the export. | [From Query](/3.1/exports/from-query.html) | 
 |`Maatwebsite\Excel\Concerns\FromView`| Use a (Blade) view to to populate the export. | [From View](/3.1/exports/from-view.html) |
 |`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
 |`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
 |`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |
+|`Maatwebsite\Excel\Concerns\WithColumnWidths`| Set Column widths. | |
+|`Maatwebsite\Excel\Concerns\WithCustomChunkSize`| Allows Exportables to define their chunk size. | |
 |`Maatwebsite\Excel\Concerns\WithCustomCsvSettings`| Allows to run custom Csv settings for this specific exportable. | [Custom CSV Settings](/3.1/exports/settings.html) |
 |`Maatwebsite\Excel\Concerns\WithCustomQuerySize`| Allows Exportables that implement the FromQuery concern to provide their own custom query size. | [Custom Query Size](/3.1/exports/queued.html#custom-query-size) |
 |`Maatwebsite\Excel\Concerns\WithCustomStartCell`| Allows to specify a custom start cell. Do note that this is only supported for FromCollection exports. | [Custom start cell](/3.1/exports/collection.html#custom-start-cell) |
+|`Maatwebsite\Excel\Concerns\WithCustomValueBinder`| Allows to specify a custom value binder. | |
 |`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
 |`Maatwebsite\Excel\Concerns\WithEvents`| Register events to hook into the PhpSpreadsheet process. | [Events](/3.1/exports/extending.html#events) |
 |`Maatwebsite\Excel\Concerns\WithFormatData`| Enable data formatting. | |
@@ -24,7 +28,9 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\WithMapping`| Format the row before it's written to the file. | [Mapping data](/3.1/exports/mapping.html) |
 |`Maatwebsite\Excel\Concerns\WithMultipleSheets`| Enable multi-sheet support. Each sheet can have its own concerns (except this one). | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
 |`Maatwebsite\Excel\Concerns\WithPreCalculateFormulas`| Forces PhpSpreadsheet to recalculate all formulae in a workbook when saving, so that the pre-calculated values are immediately available to MS Excel or other office spreadsheet viewer when opening the file. | |
+|`Maatwebsite\Excel\Concerns\WithProperties`| Allows setting properties on the document. (title, description, creator, lastModifiedBy, subject, keywords, category, manager, company) | |
 |`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null value. | [Strict null comparisons](/3.1/exports/collection.html#strict-null-comparisons) |
+|`Maatwebsite\Excel\Concerns\WithStyles`| Allows setting styles on worksheets. | |
 |`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
 
 ### Traits

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -28,7 +28,7 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\WithMapping`| Format the row before it's written to the file. | [Mapping data](/3.1/exports/mapping.html) |
 |`Maatwebsite\Excel\Concerns\WithMultipleSheets`| Enable multi-sheet support. Each sheet can have its own concerns (except this one). | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
 |`Maatwebsite\Excel\Concerns\WithPreCalculateFormulas`| Forces PhpSpreadsheet to recalculate all formulae in a workbook when saving, so that the pre-calculated values are immediately available to MS Excel or other office spreadsheet viewer when opening the file. | |
-|`Maatwebsite\Excel\Concerns\WithProperties`| Allows setting properties on the document. (title, description, creator, lastModifiedBy, subject, keywords, category, manager, company) | |
+|`Maatwebsite\Excel\Concerns\WithProperties`| Allows setting properties on the document.| [Properties](/3.1/exports/settings.html#properties) |
 |`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null value. | [Strict null comparisons](/3.1/exports/collection.html#strict-null-comparisons) |
 |`Maatwebsite\Excel\Concerns\WithStyles`| Allows setting styles on worksheets. | [Styles](/3.1/exports/column-formatting.html#styling) |
 |`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -23,7 +23,6 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\WithCustomValueBinder`| Allows to specify a custom value binder. | |
 |`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
 |`Maatwebsite\Excel\Concerns\WithEvents`| Register events to hook into the PhpSpreadsheet process. | [Events](/3.1/exports/extending.html#events) |
-|`Maatwebsite\Excel\Concerns\WithFormatData`| Enable data formatting. | |
 |`Maatwebsite\Excel\Concerns\WithHeadings`| Prepend a heading row. | [Adding a heading row](/3.1/exports/mapping.html#adding-a-heading-row) |
 |`Maatwebsite\Excel\Concerns\WithMapping`| Format the row before it's written to the file. | [Mapping data](/3.1/exports/mapping.html) |
 |`Maatwebsite\Excel\Concerns\WithMultipleSheets`| Enable multi-sheet support. Each sheet can have its own concerns (except this one). | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |

--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -11,21 +11,21 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\FromIterator`| Use an iterator to populate the export. | |
 |`Maatwebsite\Excel\Concerns\FromQuery`| Use an Eloquent query to populate the export. | [From Query](/3.1/exports/from-query.html) | 
 |`Maatwebsite\Excel\Concerns\FromView`| Use a (Blade) view to to populate the export. | [From View](/3.1/exports/from-view.html) |
-|`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
+|`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
+|`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
+|`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |
+|`Maatwebsite\Excel\Concerns\WithCustomCsvSettings`| Allows to run custom Csv settings for this specific exportable. | [Custom CSV Settings](/3.1/exports/settings.html) |
+|`Maatwebsite\Excel\Concerns\WithCustomQuerySize`| Allows Exportables that implement the FromQuery concern to provide their own custom query size. | [Custom Query Size](/3.1/exports/queued.html#custom-query-size) |
+|`Maatwebsite\Excel\Concerns\WithCustomStartCell`| Allows to specify a custom start cell. Do note that this is only supported for FromCollection exports. | [Custom start cell](/3.1/exports/collection.html#custom-start-cell) |
+|`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
+|`Maatwebsite\Excel\Concerns\WithEvents`| Register events to hook into the PhpSpreadsheet process. | [Events](/3.1/exports/extending.html#events) |
+|`Maatwebsite\Excel\Concerns\WithFormatData`| Enable data formatting. | |
 |`Maatwebsite\Excel\Concerns\WithHeadings`| Prepend a heading row. | [Adding a heading row](/3.1/exports/mapping.html#adding-a-heading-row) |
 |`Maatwebsite\Excel\Concerns\WithMapping`| Format the row before it's written to the file. | [Mapping data](/3.1/exports/mapping.html) |
-|`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | [Formatting columns](/3.1/exports/column-formatting.html) |
 |`Maatwebsite\Excel\Concerns\WithMultipleSheets`| Enable multi-sheet support. Each sheet can have its own concerns (except this one). | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
-|`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Auto size](/3.1/exports/column-formatting.html#auto-size) |
-|`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null value. | [Strict null comparisons](/3.1/exports/collection.html#strict-null-comparisons) |
-|`Maatwebsite\Excel\Concerns\WithEvents`| Register events to hook into the PhpSpreadsheet process. | [Events](/3.1/exports/extending.html#events) |
-|`Maatwebsite\Excel\Concerns\WithCustomQuerySize`| Allows Exportables that implement the FromQuery concern to provide their own custom query size. | [Custom Query Size](/3.1/exports/queued.html#custom-query-size) |
-|`Maatwebsite\Excel\Concerns\WithCustomCsvSettings`| Allows to run custom Csv settings for this specific exportable. | [Custom CSV Settings](/3.1/exports/settings.html) |
-|`Maatwebsite\Excel\Concerns\WithCharts`| Allows to run one or multiple PhpSpreadsheet Chart instances. | |
-|`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
-|`Maatwebsite\Excel\Concerns\WithCustomStartCell`| Allows to specify a custom start cell. Do note that this is only supported for FromCollection exports. | [Custom start cell](/3.1/exports/collection.html#custom-start-cell) |
 |`Maatwebsite\Excel\Concerns\WithPreCalculateFormulas`| Forces PhpSpreadsheet to recalculate all formulae in a workbook when saving, so that the pre-calculated values are immediately available to MS Excel or other office spreadsheet viewer when opening the file. | |
-|`Maatwebsite\Excel\Concerns\WithFormatData`| Enable data formatting. | |
+|`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null value. | [Strict null comparisons](/3.1/exports/collection.html#strict-null-comparisons) |
+|`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | [Multiple Sheets](/3.1/exports/multiple-sheets.html) |
 
 ### Traits
 


### PR DESCRIPTION
While looking through documentation today i noticed there were several export concerns in the code base that were not documented on the 'export concerns page', so I added them in this PR. The concerns are now also in alphabetical order (In a seperate commit, so the diff can be viewed without that change.)