### PR TITLE
Typo

### DIFF
--- a/3.1/exports/settings.md
+++ b/3.1/exports/settings.md
@@ -72,7 +72,7 @@ class InvoicesExport implements WithCustomCsvSettings
 }
 ```
 
-### Available csv settings settings
+### Available csv settings
 
 * `delimiter`
 * `enclosure`


### PR DESCRIPTION
word `settings` repeated twice