### PR TITLE
Added documentation to further clarify how to download the Excel file…

### DIFF
--- a/3.1/exports/multiple-sheets.md
+++ b/3.1/exports/multiple-sheets.md
@@ -40,8 +40,9 @@ class InvoicesExport implements WithMultipleSheets
 
 ## Sheet classes
 
-The `InvoicesPerMonthSheet` can implement concerns like `FromQuery`, `FromCollection`, ... 
+The `InvoicesPerMonthSheet` can implement concerns like `FromQuery`, `FromCollection`, `FromView`, ... 
 
+_Note: The WithTitle concern is needed in order to name each sheet using the `title()` method_
 ```php
 namespace App\Exports\Sheets;
 
@@ -80,10 +81,10 @@ class InvoicesPerMonthSheet implements FromQuery, WithTitle
 }
 ```
 
-This will now download an xlsx of all invoices from the current year, with 12 worksheets representing each month of the year.
+The code below can be implemented in any class in order to download an xlsx of all invoices from the current year, with 12 worksheets representing each month of the year.
 
 ```php
-public function download() 
+public function downloadInvoices() 
 {
     return (new InvoicesExport(2018))->download('invoices.xlsx');
 }


### PR DESCRIPTION
Hi there, I have added a documentation suggestion which I think will help further clarify the MultipleSheets functionality of your excellent Laravel Package:

1) I renamed the example function named 'download', which is to be implemented by the user in any class to downloadInvoices.
I did this because it was confusing whether I was to implement it as part of InvoiceExport, or the Sheet class (since it was displayed directly below that code). 

Hopefully by renaming it to downloadInvoices, and adding extra documentation, the user will clearly understand  that it is example code that can be implemented anywhere in their codebase including a controller etc.

2) Upon first read of the docs, I also never understood that the WithTitle concer was needed if I wanted to rename my sheet - and I had to cycle back to the documentation when it was not working.  I have therefore updated the docs to explicitly mention that the WithTitle concern is needed if renaming is needed.

By adding an explicit note, that WithTitle concern is needed, hopefully the reader may be saved time.