### PR TITLE
Update syntax on laravel-excel: 3.1

### DIFF
--- a/3.1/exports/export-formats.md
+++ b/3.1/exports/export-formats.md
@@ -8,19 +8,19 @@ to explicitly configure the export format, you can pass it through as 2nd parame
 ## XLSX
 
 ```php
-return (new InvoicesExport)->download('invoices.xlsx', \Maatwebsite\Excel\Excel::XLSX);
+return Excel::download(new InvoicesExport, 'invoices.xlsx', \Maatwebsite\Excel\Excel::XLSX);
 ```
 
 ## CSV
 
 ```php
-return (new InvoicesExport)->download('invoices.csv', \Maatwebsite\Excel\Excel::CSV);
+return Excel::download(new InvoicesExport, 'invoices.csv', \Maatwebsite\Excel\Excel::CSV);
 ```
 
 By default the CSV is download with Content Type `text/plain`, if you want to customize the Content-Type header, you can do so by passing it as 3rd parameter.
 
 ```php
-return (new InvoicesExport)->download('invoices.csv', \Maatwebsite\Excel\Excel::CSV, [
+return Excel::download(new InvoicesExport, 'invoices.csv', \Maatwebsite\Excel\Excel::CSV, [
       'Content-Type' => 'text/csv',
 ]);
 ```
@@ -32,25 +32,25 @@ You may have a look at our [Laravel CSV](/csv/1.0/getting-started/) package as w
 ## TSV
 
 ```php
-return (new InvoicesExport)->download('invoices.tsv', \Maatwebsite\Excel\Excel::TSV);
+return Excel::download(new InvoicesExport, 'invoices.tsv', \Maatwebsite\Excel\Excel::TSV);
 ```
 
 ## ODS
 
 ```php
-return (new InvoicesExport)->download('invoices.ods', \Maatwebsite\Excel\Excel::ODS);
+return Excel::download(new InvoicesExport, 'invoices.ods', \Maatwebsite\Excel\Excel::ODS);
 ```
 
 ## XLS
 
 ```php
-return (new InvoicesExport)->download('invoices.xls', \Maatwebsite\Excel\Excel::XLS);
+return Excel::download(new InvoicesExport, 'invoices.xls', \Maatwebsite\Excel\Excel::XLS);
 ```
 
 ## HTML
 
 ```php
-return (new InvoicesExport)->download('invoices.html', \Maatwebsite\Excel\Excel::HTML);
+return Excel::download(new InvoicesExport, 'invoices.html', \Maatwebsite\Excel\Excel::HTML);
 ```
 
 ::: warning Exporting to PDF
@@ -60,17 +60,17 @@ If you'd like to export to PDF, you must now install a PDF rendering library you
 ## MPDF
 
 ```php
-return (new InvoicesExport)->download('invoices.pdf', \Maatwebsite\Excel\Excel::MPDF);
+return Excel::download(new InvoicesExport, 'invoices.pdf', \Maatwebsite\Excel\Excel::MPDF);
 ```
 
 ## DOMPDF
 
 ```php
-return (new InvoicesExport)->download('invoices.pdf', \Maatwebsite\Excel\Excel::DOMPDF);
+return Excel::download(new InvoicesExport, 'invoices.pdf', \Maatwebsite\Excel\Excel::DOMPDF);
 ```
 
 ## TCPDF
 
 ```php
-return (new InvoicesExport)->download('invoices.pdf', \Maatwebsite\Excel\Excel::TCPDF);
+return Excel::download(new InvoicesExport, 'invoices.pdf', \Maatwebsite\Excel\Excel::TCPDF);
 ```


### PR DESCRIPTION
It's return an error when using the old syntax
```php
return (new SeleksiParadeExport)->download('seleksi-parade.xlsx');


Call to undefined method App\Exports\SeleksiParadeExport::download()
```

if permitted, can you add the `hacktoberfest-accepted` label on this PR please...