### PR TITLE
Update installation.md - composer require

### DIFF
--- a/3.1/getting-started/installation.md
+++ b/3.1/getting-started/installation.md
@@ -20,7 +20,7 @@
 Require this package in the `composer.json` of your Laravel project. This will download the package and _PhpSpreadsheet_.
 
 ```
-composer require maatwebsite/excel
+composer require maatwebsite/excel:3.1.48 -W
 ```
 
 The `Maatwebsite\Excel\ExcelServiceProvider` is __auto-discovered__ and registered by default.


### PR DESCRIPTION
It is currently (?) required to specify the latest Github version and the -W flag to successfully install using composer require. Using the method described here, composer require throws the warning 

Package phpoffice/phpexcel is abandoned, you should avoid using it. Use phpoffice/phpspreadsheet instead.