### PR TITLE
Add missing use statement for ImportFailed

### DIFF
--- a/3.1/imports/queued.md
+++ b/3.1/imports/queued.md
@@ -73,6 +73,7 @@ use App\User;
 use App\Notifications\ImportHasFailedNotification;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\ImportFailed;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 

--- a/4.x/imports/queued.md
+++ b/4.x/imports/queued.md
@@ -73,6 +73,7 @@ use App\User;
 use App\Notifications\ImportHasFailedNotification;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\ImportFailed;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 


### PR DESCRIPTION
Used in example under "Handling failures in queued imports" in 3.1 and 4.x