### PR TITLE
add start row page to Imports section

### DIFF
--- a/3.1/imports/start-row.md
+++ b/3.1/imports/start-row.md
@@ -1,0 +1,28 @@
+# Start row
+
+[[toc]]
+
+If you want to skip a certain number of rows during an import, you can specify the starting row by implementing the `WithStartRow` concern.
+
+```php
+namespace App\Imports;
+
+use App\User;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithStartRow;
+
+class UsersImport implements ToModel, WithStartRow
+{
+    public function model(array $row)
+    {
+        return new User([
+            'name' => $row[0],
+        ]);
+    }
+
+    public function startRow(): int
+    {
+        return 2;
+    }
+}
+```


### PR DESCRIPTION
I noticed that the `WithStartRow` feature is not documented. This feature allows us to skip a specified number of rows during import. I find it particularly useful for skipping headers when we prefer not to use `WithHeadingRow`.