### PR TITLE
Fix: Missing property of 'Invoices' in InvoicesExport class

### DIFF
--- a/3.1/exports/collection.md
+++ b/3.1/exports/collection.md
@@ -148,6 +148,8 @@ use Maatwebsite\Excel\Concerns\FromCollection;
 
 class InvoicesExport implements FromCollection
 {
+    protected $invoices;
+
     public function __construct(InvoicesRepository $invoices)
     {
         $this->invoices = $invoices;


### PR DESCRIPTION
This **PR** fixes the Missing property of  'Invoices' in InvoicesExport class when it needed to be dependency injection because it isn't uses property promotion.